### PR TITLE
 获取酷Q "音乐自定义" 代码 修正错误

### DIFF
--- a/Native.Csharp.Sdk/Cqp/Api/CqApi.cs
+++ b/Native.Csharp.Sdk/Cqp/Api/CqApi.cs
@@ -213,7 +213,7 @@ namespace Native.Csharp.Sdk.Cqp.Api
 			}
 			if (!string.IsNullOrEmpty (imgUrl))
 			{
-				@string.AppendFormat (",iamge={0}", CqCode_Trope (imgUrl, true));
+				@string.AppendFormat (",image={0}", CqCode_Trope (imgUrl, true));
 			}
 			return string.Format ("[CQ:music,type=custom{0}]", @string.ToString ());
 		}


### PR DESCRIPTION
 获取酷Q "音乐自定义" 代码 修正错误
iamge =>image
[CQ:music,type=custom,url={1},audio={2},title={3},content={4},image={5}]
{1}为分享链接，即点击分享后进入的音乐页面（如歌曲介绍页）。
{2}为音频链接（如mp3链接）。
{3}为音乐的标题，建议12字以内。
{4}为音乐的简介，建议30字以内。该参数可被忽略。
{5}为音乐的封面图片链接。若参数为空或被忽略，则显示默认图片。
详情见:https://d.cqp.me/Pro/CQ%E7%A0%81